### PR TITLE
fix: select field id

### DIFF
--- a/packages/bumbag/src/Select/Select.tsx
+++ b/packages/bumbag/src/Select/Select.tsx
@@ -78,8 +78,6 @@ const useProps = createHook<SelectProps>(
 
     const ref = React.useRef();
 
-    const uid = useUniqueId();
-
     const { isFocused, inputProps: labelPlaceholderInputProps } = useLabelPlaceholder({
       enabled: Boolean(label),
       ...props,
@@ -135,7 +133,6 @@ const useProps = createHook<SelectProps>(
 
     const boxProps = Box.useProps({
       ...omitCSSProps(restProps),
-      id: uid,
       ...selectProps,
       ...labelPlaceholderInputProps,
       className: undefined,
@@ -154,9 +151,7 @@ const useProps = createHook<SelectProps>(
               <Box className={labelWrapperClassName}>
                 {/*
                   // @ts-ignore */}
-                <Text use="label" htmlFor={selectProps?.id || uid}>
-                  {label}
-                </Text>
+                <Text use="label">{label}</Text>
               </Box>
             </>
           )}


### PR DESCRIPTION
Currently, the `for` attribute on the `SelectField` label is different than the `id` on the `select` element.

### Before PR
![image](https://user-images.githubusercontent.com/40446421/140830225-6d034c0e-978d-4cf8-a15c-f5c1398edc20.png)

### After PR
![image](https://user-images.githubusercontent.com/40446421/140830254-7bcbfd0b-714d-4b29-9e3d-6f857cda65f0.png)
