### PR TITLE
allow search debounce timer to be set via property

### DIFF
--- a/packages/bumbag/src/Autosuggest/Autosuggest.tsx
+++ b/packages/bumbag/src/Autosuggest/Autosuggest.tsx
@@ -32,6 +32,8 @@ export type LocalAutosuggestProps = {
   cacheKey?: string;
   /** If the `label` prop is supplied, is it contained inside the autosuggest? */
   containLabel?: boolean;
+  /** The time in milliseconds for the debounce interval used to handle text input. **/
+  debounceInterval?: number;
   /** Whether or not the invocation of loadOptions should be deferred until it the Autosuggest is opened. */
   defer?: boolean;
   /** Indicates if the  Autosuggest is disabled. */
@@ -218,6 +220,7 @@ const useProps = createHook<AutosuggestProps>(
       cacheKey,
       containLabel,
       clearButtonProps,
+      debounceInterval,
       disabled,
       dropdownMenuInitialState,
       emptyText,
@@ -332,7 +335,7 @@ const useProps = createHook<AutosuggestProps>(
 
     //////////////////////////////////////////////////
 
-    const debouncedInputValue = useDebounce(inputValue, 500);
+    const debouncedInputValue = useDebounce(inputValue, debounceInterval || 500);
 
     const getOptions = React.useCallback(
       async ({ loadVariables, page, searchText = '' }) => {

--- a/packages/bumbag/src/SelectMenu/SelectMenu.tsx
+++ b/packages/bumbag/src/SelectMenu/SelectMenu.tsx
@@ -34,6 +34,8 @@ export type LocalSelectMenuProps = {
   cacheKey?: string;
   /** If the `label` prop is supplied, is it contained inside the select? */
   containLabel?: boolean;
+  /** The time in milliseconds for the debounce interval used to handle text input. **/
+  debounceInterval?: number;
   /** Whether or not the invocation of loadOptions should be deferred until it the Autosuggest is opened. */
   defer?: boolean;
   /** Indicates if the  Autosuggest is disabled. */
@@ -142,6 +144,7 @@ const useProps = createHook<SelectMenuProps>(
       buttonProps,
       cacheKey,
       containLabel,
+      debounceInterval,
       disabled,
       disableClear,
       dropdownMenuInitialState,
@@ -276,7 +279,7 @@ const useProps = createHook<SelectMenuProps>(
 
     //////////////////////////////////////////////////
 
-    const debouncedInputValue = useDebounce(searchText, 500);
+    const debouncedInputValue = useDebounce(searchText, debounceInterval || 500);
 
     const getOptions = React.useCallback(
       async ({ loadVariables, page, searchText = '' }) => {

--- a/website/pages/docs/form/autosuggest.mdx
+++ b/website/pages/docs/form/autosuggest.mdx
@@ -1072,6 +1072,12 @@ If the `label` prop is supplied, is it contained inside the autosuggest?
 
 <Divider marginTop="major-2" marginBottom="major-2" />
 
+**<Code fontSize="150" marginRight="major-1">debounceInterval</Code>** <Code fontSize="100" palette="primary">number</Code>
+
+What should the debounce timer be set to (default: 500)?
+
+<Divider marginTop="major-2" marginBottom="major-2" />
+
 **<Code fontSize="150" marginRight="major-1">defer</Code>** <Code fontSize="100" palette="primary">boolean</Code> 
 
 Whether or not the invocation of loadOptions should be deferred until it the Autosuggest is opened.

--- a/website/pages/docs/form/select-menu.mdx
+++ b/website/pages/docs/form/select-menu.mdx
@@ -1758,6 +1758,12 @@ If the `label` prop is supplied, is it contained inside the select?
 
 <Divider marginTop="major-2" marginBottom="major-2" />
 
+**<Code fontSize="150" marginRight="major-1">debounceInterval</Code>** <Code fontSize="100" palette="primary">number</Code>
+
+If search is enabled, what should the debounce timer be set to (default: 500)?  
+
+<Divider marginTop="major-2" marginBottom="major-2" />
+
 **<Code fontSize="150" marginRight="major-1">defer</Code>** <Code fontSize="100" palette="primary">boolean</Code> 
 
 Whether or not the invocation of loadOptions should be deferred until it the Autosuggest is opened.


### PR DESCRIPTION
This tiny change allows the debounce timer to be configurable for Autosuggest & SelectMenu, giving a bit more control authority to the implementer.