### PR TITLE
Fix path.includes issue in web theme

### DIFF
--- a/packages/bumbag/src/utils/theme.ts
+++ b/packages/bumbag/src/utils/theme.ts
@@ -35,7 +35,7 @@ export function theme(themeKey: string, path?: string, defaultValue?: any) {
       colorModeThemeOverrides = get(props, `overrides.${colorModeSelector}`);
     }
 
-    if (path && path.includes('styles')) {
+    if (path && path.includes && path.includes('styles')) {
       const defaultThemeValue = isFunction(defaultTheme) ? defaultTheme(props) : defaultTheme;
       const defaultThemeOverridesValue = isFunction(defaultThemeOverrides)
         ? defaultThemeOverrides(props)


### PR DESCRIPTION
Looks like there's a minor discrepancy in the web side of theme.ts from the native package where we're not checking for path.includes existing.  This is causing some issues for me on 2.7.14.  I'd appreciate if we could review and release this ASAP, as this is blocking a build from going to prod for us.