### PR TITLE
Allow spacing unit to be exported

### DIFF
--- a/packages/bumbag/src/types/css.ts
+++ b/packages/bumbag/src/types/css.ts
@@ -15,7 +15,7 @@ import React from 'react';
 type Unit = 'px' | 'em' | 'rem' | '%' | 'ch' | 'vw' | 'vh';
 type UnitWithValue = `${number}${Unit}`;
 
-type SpacingUnit = UnitWithValue | `major-${number}` | `minor-${number}` | `-major-${number}` | `-minor-${number}` | 'inherit' | 'initial' | 'revert' | 'unset';
+export type SpacingUnit = UnitWithValue | `major-${number}` | `minor-${number}` | `-major-${number}` | `-minor-${number}` | 'inherit' | 'initial' | 'revert' | 'unset';
 
 export type CSSProperties = {
   _hover?: CSSProperties | boolean;


### PR DESCRIPTION
By exporting spacing units, we play nice with others who may need to use the type...