### PR TITLE
fix: remove search input autofocus

### DIFF
--- a/packages/bumbag/src/SelectMenu/SelectMenu.tsx
+++ b/packages/bumbag/src/SelectMenu/SelectMenu.tsx
@@ -570,7 +570,6 @@ const useProps = createHook<SelectMenuProps>(
                     onChange={handleChangeInput}
                     value={searchText}
                     searchInputProps={searchInputProps}
-                    autoFocus={isDropdown}
                   />
                 )}
                 {hasTags && selectedOptions.length > 0 && (
@@ -776,7 +775,7 @@ function SelectMenuButton(props: any) {
 //////////////////////////////////////////////////////////////////
 
 function SelectMenuSearchInput(props: any) {
-  const { autoFocus, onChange, searchInputProps, value, ...restProps } = props;
+  const { onChange, searchInputProps, value, ...restProps } = props;
 
   const { overrides, themeKey } = React.useContext(SelectMenuContext);
 
@@ -801,7 +800,6 @@ function SelectMenuSearchInput(props: any) {
         overrides={overrides}
         placeholder="Type to search..."
         value={value}
-        autoFocus={autoFocus}
         {...searchInputProps}
       />
     </Box>

--- a/packages/bumbag/src/SelectMenu/SelectMenu.tsx
+++ b/packages/bumbag/src/SelectMenu/SelectMenu.tsx
@@ -777,7 +777,7 @@ function SelectMenuButton(props: any) {
 //////////////////////////////////////////////////////////////////
 
 function SelectMenuSearchInput(props: any) {
-  const { onChange, searchInputProps, value, ...restProps } = props;
+  const { autoFocus, onChange, searchInputProps, value, ...restProps } = props;
 
   const { overrides, themeKey } = React.useContext(SelectMenuContext);
 
@@ -802,7 +802,7 @@ function SelectMenuSearchInput(props: any) {
         overrides={overrides}
         placeholder="Type to search..."
         value={value}
-        autoFocus
+        autoFocus={autoFocus}
         {...searchInputProps}
       />
     </Box>

--- a/packages/bumbag/src/SelectMenu/SelectMenu.tsx
+++ b/packages/bumbag/src/SelectMenu/SelectMenu.tsx
@@ -570,7 +570,7 @@ const useProps = createHook<SelectMenuProps>(
                   <SelectMenuSearchInput
                     onChange={handleChangeInput}
                     value={searchText}
-                    autoFocus
+                    autoFocus={isDropdown}
                     searchInputProps={searchInputProps}
                   />
                 )}

--- a/packages/bumbag/src/SelectMenu/SelectMenu.tsx
+++ b/packages/bumbag/src/SelectMenu/SelectMenu.tsx
@@ -196,6 +196,7 @@ const useProps = createHook<SelectMenuProps>(
     //////////////////////////////////////////////////
 
     const dropdownMenu = DropdownMenu.useState({
+      animated: true,
       loop: true,
       gutter: 4,
       ...dropdownMenuInitialState,
@@ -569,6 +570,7 @@ const useProps = createHook<SelectMenuProps>(
                   <SelectMenuSearchInput
                     onChange={handleChangeInput}
                     value={searchText}
+                    autoFocus={!isDropdown}
                     searchInputProps={searchInputProps}
                   />
                 )}
@@ -800,6 +802,7 @@ function SelectMenuSearchInput(props: any) {
         overrides={overrides}
         placeholder="Type to search..."
         value={value}
+        autoFocus
         {...searchInputProps}
       />
     </Box>

--- a/packages/bumbag/src/SelectMenu/SelectMenu.tsx
+++ b/packages/bumbag/src/SelectMenu/SelectMenu.tsx
@@ -570,7 +570,7 @@ const useProps = createHook<SelectMenuProps>(
                   <SelectMenuSearchInput
                     onChange={handleChangeInput}
                     value={searchText}
-                    autoFocus={!isDropdown}
+                    autoFocus
                     searchInputProps={searchInputProps}
                   />
                 )}

--- a/website/mdx-manifest.json
+++ b/website/mdx-manifest.json
@@ -1,6 +1,6 @@
 [
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/addons/highlighted-code.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/addons/highlighted-code.mdx",
     "fileName": "highlighted-code.mdx",
     "name": "highlighted-code",
     "path": "/addons/highlighted-code",
@@ -11,7 +11,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/addons/markdown.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/addons/markdown.mdx",
     "fileName": "markdown.mdx",
     "name": "markdown",
     "path": "/addons/markdown",
@@ -22,7 +22,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/blocks/hero.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/blocks/hero.mdx",
     "fileName": "hero.mdx",
     "name": "hero",
     "path": "/blocks/hero",
@@ -37,7 +37,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/breakpoints.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/breakpoints.mdx",
     "fileName": "breakpoints.mdx",
     "name": "breakpoints",
     "path": "/breakpoints",
@@ -52,7 +52,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/color-modes.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/color-modes.mdx",
     "fileName": "color-modes.mdx",
     "name": "color-modes",
     "path": "/color-modes",
@@ -67,7 +67,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/action-buttons.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/action-buttons.mdx",
     "fileName": "action-buttons.mdx",
     "name": "action-buttons",
     "path": "/components/action-buttons",
@@ -78,7 +78,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/alert.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/alert.mdx",
     "fileName": "alert.mdx",
     "name": "alert",
     "path": "/components/alert",
@@ -89,7 +89,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/avatar.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/avatar.mdx",
     "fileName": "avatar.mdx",
     "name": "avatar",
     "path": "/components/avatar",
@@ -100,7 +100,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/badge.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/badge.mdx",
     "fileName": "badge.mdx",
     "name": "badge",
     "path": "/components/badge",
@@ -111,7 +111,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/breadcrumb.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/breadcrumb.mdx",
     "fileName": "breadcrumb.mdx",
     "name": "breadcrumb",
     "path": "/components/breadcrumb",
@@ -122,7 +122,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/button.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/button.mdx",
     "fileName": "button.mdx",
     "name": "button",
     "path": "/components/button",
@@ -133,7 +133,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/callout.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/callout.mdx",
     "fileName": "callout.mdx",
     "name": "callout",
     "path": "/components/callout",
@@ -144,7 +144,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/card.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/card.mdx",
     "fileName": "card.mdx",
     "name": "card",
     "path": "/components/card",
@@ -155,7 +155,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/dialog.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/dialog.mdx",
     "fileName": "dialog.mdx",
     "name": "dialog",
     "path": "/components/dialog",
@@ -166,7 +166,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/divider.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/divider.mdx",
     "fileName": "divider.mdx",
     "name": "divider",
     "path": "/components/divider",
@@ -177,7 +177,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/dropdown-menu.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/dropdown-menu.mdx",
     "fileName": "dropdown-menu.mdx",
     "name": "dropdown-menu",
     "path": "/components/dropdown-menu",
@@ -188,7 +188,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/icon.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/icon.mdx",
     "fileName": "icon.mdx",
     "name": "icon",
     "path": "/components/icon",
@@ -199,7 +199,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/image.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/image.mdx",
     "fileName": "image.mdx",
     "name": "image",
     "path": "/components/image",
@@ -210,7 +210,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/key.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/key.mdx",
     "fileName": "key.mdx",
     "name": "key",
     "path": "/components/key",
@@ -221,7 +221,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/menu.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/menu.mdx",
     "fileName": "menu.mdx",
     "name": "menu",
     "path": "/components/menu",
@@ -232,7 +232,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/navigation.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/navigation.mdx",
     "fileName": "navigation.mdx",
     "name": "navigation",
     "path": "/components/navigation",
@@ -243,7 +243,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/pagination.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/pagination.mdx",
     "fileName": "pagination.mdx",
     "name": "pagination",
     "path": "/components/pagination",
@@ -254,7 +254,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/popover.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/popover.mdx",
     "fileName": "popover.mdx",
     "name": "popover",
     "path": "/components/popover",
@@ -265,7 +265,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/progress-bar.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/progress-bar.mdx",
     "fileName": "progress-bar.mdx",
     "name": "progress-bar",
     "path": "/components/progress-bar",
@@ -276,7 +276,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/rating.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/rating.mdx",
     "fileName": "rating.mdx",
     "name": "rating",
     "path": "/components/rating",
@@ -287,7 +287,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/side-nav.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/side-nav.mdx",
     "fileName": "side-nav.mdx",
     "name": "side-nav",
     "path": "/components/side-nav",
@@ -298,7 +298,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/spinner.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/spinner.mdx",
     "fileName": "spinner.mdx",
     "name": "spinner",
     "path": "/components/spinner",
@@ -309,7 +309,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/table.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/table.mdx",
     "fileName": "table.mdx",
     "name": "table",
     "path": "/components/table",
@@ -320,7 +320,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/tabs.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/tabs.mdx",
     "fileName": "tabs.mdx",
     "name": "tabs",
     "path": "/components/tabs",
@@ -331,7 +331,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/tag.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/tag.mdx",
     "fileName": "tag.mdx",
     "name": "tag",
     "path": "/components/tag",
@@ -342,7 +342,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/toast.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/toast.mdx",
     "fileName": "toast.mdx",
     "name": "toast",
     "path": "/components/toast",
@@ -353,7 +353,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/tooltip.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/tooltip.mdx",
     "fileName": "tooltip.mdx",
     "name": "tooltip",
     "path": "/components/tooltip",
@@ -364,7 +364,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/top-nav.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/top-nav.mdx",
     "fileName": "top-nav.mdx",
     "name": "top-nav",
     "path": "/components/top-nav",
@@ -375,7 +375,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/composition.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/composition.mdx",
     "fileName": "composition.mdx",
     "name": "composition",
     "path": "/composition",
@@ -390,7 +390,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/fonts.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/fonts.mdx",
     "fileName": "fonts.mdx",
     "name": "fonts",
     "path": "/fonts",
@@ -404,7 +404,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/autosuggest.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/autosuggest.mdx",
     "fileName": "autosuggest.mdx",
     "name": "autosuggest",
     "path": "/form/autosuggest",
@@ -415,7 +415,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/checkbox-group.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/checkbox-group.mdx",
     "fileName": "checkbox-group.mdx",
     "name": "checkbox-group",
     "path": "/form/checkbox-group",
@@ -426,7 +426,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/checkbox.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/checkbox.mdx",
     "fileName": "checkbox.mdx",
     "name": "checkbox",
     "path": "/form/checkbox",
@@ -437,7 +437,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/field-stack.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/field-stack.mdx",
     "fileName": "field-stack.mdx",
     "name": "field-stack",
     "path": "/form/field-stack",
@@ -448,7 +448,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/field-wrapper.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/field-wrapper.mdx",
     "fileName": "field-wrapper.mdx",
     "name": "field-wrapper",
     "path": "/form/field-wrapper",
@@ -459,7 +459,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/form-libraries.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/form-libraries.mdx",
     "fileName": "form-libraries.mdx",
     "name": "form-libraries",
     "path": "/form/form-libraries",
@@ -472,7 +472,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/input.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/input.mdx",
     "fileName": "input.mdx",
     "name": "input",
     "path": "/form/input",
@@ -483,7 +483,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/label.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/label.mdx",
     "fileName": "label.mdx",
     "name": "label",
     "path": "/form/label",
@@ -494,7 +494,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/option-buttons.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/option-buttons.mdx",
     "fileName": "option-buttons.mdx",
     "name": "option-buttons",
     "path": "/form/option-buttons",
@@ -505,7 +505,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/radio-group.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/radio-group.mdx",
     "fileName": "radio-group.mdx",
     "name": "radio-group",
     "path": "/form/radio-group",
@@ -516,7 +516,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/radio.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/radio.mdx",
     "fileName": "radio.mdx",
     "name": "radio",
     "path": "/form/radio",
@@ -527,7 +527,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/select-menu.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/select-menu.mdx",
     "fileName": "select-menu.mdx",
     "name": "select-menu",
     "path": "/form/select-menu",
@@ -538,7 +538,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/select.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/select.mdx",
     "fileName": "select.mdx",
     "name": "select",
     "path": "/form/select",
@@ -549,7 +549,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/switch-group.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/switch-group.mdx",
     "fileName": "switch-group.mdx",
     "name": "switch-group",
     "path": "/form/switch-group",
@@ -560,7 +560,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/switch.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/switch.mdx",
     "fileName": "switch.mdx",
     "name": "switch",
     "path": "/form/switch",
@@ -571,7 +571,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/textarea.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/textarea.mdx",
     "fileName": "textarea.mdx",
     "name": "textarea",
     "path": "/form/textarea",
@@ -582,7 +582,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/getting-started.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/getting-started.mdx",
     "fileName": "getting-started.mdx",
     "name": "getting-started",
     "path": "/getting-started",
@@ -596,7 +596,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/global-styles.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/global-styles.mdx",
     "fileName": "global-styles.mdx",
     "name": "global-styles",
     "path": "/global-styles",
@@ -611,7 +611,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/hooks/use-breakpoint-value.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/hooks/use-breakpoint-value.mdx",
     "fileName": "use-breakpoint-value.mdx",
     "name": "use-breakpoint-value",
     "path": "/hooks/use-breakpoint-value",
@@ -625,7 +625,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/hooks/use-breakpoint.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/hooks/use-breakpoint.mdx",
     "fileName": "use-breakpoint.mdx",
     "name": "use-breakpoint",
     "path": "/hooks/use-breakpoint",
@@ -639,7 +639,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/hooks/use-page.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/hooks/use-page.mdx",
     "fileName": "use-page.mdx",
     "name": "use-page",
     "path": "/hooks/use-page",
@@ -653,7 +653,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/hooks/use-theme.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/hooks/use-theme.mdx",
     "fileName": "use-theme.mdx",
     "name": "use-theme",
     "path": "/hooks/use-theme",
@@ -667,7 +667,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/layout/columns.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/layout/columns.mdx",
     "fileName": "columns.mdx",
     "name": "columns",
     "path": "/layout/columns",
@@ -678,7 +678,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/layout/container.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/layout/container.mdx",
     "fileName": "container.mdx",
     "name": "container",
     "path": "/layout/container",
@@ -691,7 +691,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/layout/group.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/layout/group.mdx",
     "fileName": "group.mdx",
     "name": "group",
     "path": "/layout/group",
@@ -702,7 +702,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/layout/hide.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/layout/hide.mdx",
     "fileName": "hide.mdx",
     "name": "hide",
     "path": "/layout/hide",
@@ -713,7 +713,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/layout/level.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/layout/level.mdx",
     "fileName": "level.mdx",
     "name": "level",
     "path": "/layout/level",
@@ -726,7 +726,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/layout/set.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/layout/set.mdx",
     "fileName": "set.mdx",
     "name": "set",
     "path": "/layout/set",
@@ -737,7 +737,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/layout/show.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/layout/show.mdx",
     "fileName": "show.mdx",
     "name": "show",
     "path": "/layout/show",
@@ -748,7 +748,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/layout/stack.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/layout/stack.mdx",
     "fileName": "stack.mdx",
     "name": "stack",
     "path": "/layout/stack",
@@ -759,7 +759,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/migrating-from-fannypack.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/migrating-from-fannypack.mdx",
     "fileName": "migrating-from-fannypack.mdx",
     "name": "migrating-from-fannypack",
     "path": "/migrating-from-fannypack",
@@ -774,7 +774,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/breakpoints.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/breakpoints.mdx",
     "fileName": "breakpoints.mdx",
     "name": "breakpoints",
     "path": "/native/breakpoints",
@@ -788,7 +788,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/color-modes.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/color-modes.mdx",
     "fileName": "color-modes.mdx",
     "name": "color-modes",
     "path": "/native/color-modes",
@@ -803,7 +803,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/action-buttons.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/action-buttons.mdx",
     "fileName": "action-buttons.mdx",
     "name": "action-buttons",
     "path": "/native/components/action-buttons",
@@ -818,7 +818,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/alert.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/alert.mdx",
     "fileName": "alert.mdx",
     "name": "alert",
     "path": "/native/components/alert",
@@ -833,7 +833,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/avatar.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/avatar.mdx",
     "fileName": "avatar.mdx",
     "name": "avatar",
     "path": "/native/components/avatar",
@@ -848,7 +848,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/badge.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/badge.mdx",
     "fileName": "badge.mdx",
     "name": "badge",
     "path": "/native/components/badge",
@@ -863,7 +863,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/bottom-nav.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/bottom-nav.mdx",
     "fileName": "bottom-nav.mdx",
     "name": "bottom-nav",
     "path": "/native/components/bottom-nav",
@@ -878,7 +878,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/button.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/button.mdx",
     "fileName": "button.mdx",
     "name": "button",
     "path": "/native/components/button",
@@ -891,7 +891,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/card.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/card.mdx",
     "fileName": "card.mdx",
     "name": "card",
     "path": "/native/components/card",
@@ -906,7 +906,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/dialog-alert.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/dialog-alert.mdx",
     "fileName": "dialog-alert.mdx",
     "name": "dialog-alert",
     "path": "/native/components/dialog-alert",
@@ -921,7 +921,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/dialog.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/dialog.mdx",
     "fileName": "dialog.mdx",
     "name": "dialog",
     "path": "/native/components/dialog",
@@ -936,7 +936,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/divider.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/divider.mdx",
     "fileName": "divider.mdx",
     "name": "divider",
     "path": "/native/components/divider",
@@ -951,7 +951,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/dropdown-menu.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/dropdown-menu.mdx",
     "fileName": "dropdown-menu.mdx",
     "name": "dropdown-menu",
     "path": "/native/components/dropdown-menu",
@@ -966,7 +966,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/fab.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/fab.mdx",
     "fileName": "fab.mdx",
     "name": "fab",
     "path": "/native/components/fab",
@@ -981,7 +981,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/icon.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/icon.mdx",
     "fileName": "icon.mdx",
     "name": "icon",
     "path": "/native/components/icon",
@@ -992,7 +992,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/image.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/image.mdx",
     "fileName": "image.mdx",
     "name": "image",
     "path": "/native/components/image",
@@ -1003,7 +1003,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/menu.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/menu.mdx",
     "fileName": "menu.mdx",
     "name": "menu",
     "path": "/native/components/menu",
@@ -1017,7 +1017,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/popover.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/popover.mdx",
     "fileName": "popover.mdx",
     "name": "popover",
     "path": "/native/components/popover",
@@ -1032,7 +1032,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/progress-bar.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/progress-bar.mdx",
     "fileName": "progress-bar.mdx",
     "name": "progress-bar",
     "path": "/native/components/progress-bar",
@@ -1047,7 +1047,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/rating.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/rating.mdx",
     "fileName": "rating.mdx",
     "name": "rating",
     "path": "/native/components/rating",
@@ -1062,7 +1062,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/search-bar.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/search-bar.mdx",
     "fileName": "search-bar.mdx",
     "name": "search-bar",
     "path": "/native/components/search-bar",
@@ -1077,7 +1077,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/spinner.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/spinner.mdx",
     "fileName": "spinner.mdx",
     "name": "spinner",
     "path": "/native/components/spinner",
@@ -1088,7 +1088,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/tabs.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/tabs.mdx",
     "fileName": "tabs.mdx",
     "name": "tabs",
     "path": "/native/components/tabs",
@@ -1103,7 +1103,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/tag.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/tag.mdx",
     "fileName": "tag.mdx",
     "name": "tag",
     "path": "/native/components/tag",
@@ -1118,7 +1118,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/toast.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/toast.mdx",
     "fileName": "toast.mdx",
     "name": "toast",
     "path": "/native/components/toast",
@@ -1132,7 +1132,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/tooltip.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/tooltip.mdx",
     "fileName": "tooltip.mdx",
     "name": "tooltip",
     "path": "/native/components/tooltip",
@@ -1147,7 +1147,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/top-nav.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/top-nav.mdx",
     "fileName": "top-nav.mdx",
     "name": "top-nav",
     "path": "/native/components/top-nav",
@@ -1162,7 +1162,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/fonts.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/fonts.mdx",
     "fileName": "fonts.mdx",
     "name": "fonts",
     "path": "/native/fonts",
@@ -1177,7 +1177,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/autosuggest.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/autosuggest.mdx",
     "fileName": "autosuggest.mdx",
     "name": "autosuggest",
     "path": "/native/form/autosuggest",
@@ -1192,7 +1192,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/checkbox-group.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/checkbox-group.mdx",
     "fileName": "checkbox-group.mdx",
     "name": "checkbox-group",
     "path": "/native/form/checkbox-group",
@@ -1203,7 +1203,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/checkbox.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/checkbox.mdx",
     "fileName": "checkbox.mdx",
     "name": "checkbox",
     "path": "/native/form/checkbox",
@@ -1214,7 +1214,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/field-wrapper.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/field-wrapper.mdx",
     "fileName": "field-wrapper.mdx",
     "name": "field-wrapper",
     "path": "/native/form/field-wrapper",
@@ -1225,7 +1225,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/input.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/input.mdx",
     "fileName": "input.mdx",
     "name": "input",
     "path": "/native/form/input",
@@ -1236,7 +1236,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/picker.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/picker.mdx",
     "fileName": "picker.mdx",
     "name": "picker",
     "path": "/native/form/picker",
@@ -1250,7 +1250,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/radio-group.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/radio-group.mdx",
     "fileName": "radio-group.mdx",
     "name": "radio-group",
     "path": "/native/form/radio-group",
@@ -1261,7 +1261,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/radio.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/radio.mdx",
     "fileName": "radio.mdx",
     "name": "radio",
     "path": "/native/form/radio",
@@ -1272,7 +1272,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/select.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/select.mdx",
     "fileName": "select.mdx",
     "name": "select",
     "path": "/native/form/select",
@@ -1287,7 +1287,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/switch-group.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/switch-group.mdx",
     "fileName": "switch-group.mdx",
     "name": "switch-group",
     "path": "/native/form/switch-group",
@@ -1298,7 +1298,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/switch.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/switch.mdx",
     "fileName": "switch.mdx",
     "name": "switch",
     "path": "/native/form/switch",
@@ -1309,7 +1309,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/textarea.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/textarea.mdx",
     "fileName": "textarea.mdx",
     "name": "textarea",
     "path": "/native/form/textarea",
@@ -1324,7 +1324,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/getting-started.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/getting-started.mdx",
     "fileName": "getting-started.mdx",
     "name": "getting-started",
     "path": "/native/getting-started",
@@ -1338,7 +1338,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/hooks/use-breakpoint.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/hooks/use-breakpoint.mdx",
     "fileName": "use-breakpoint.mdx",
     "name": "use-breakpoint",
     "path": "/native/hooks/use-breakpoint",
@@ -1352,7 +1352,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/hooks/use-theme.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/hooks/use-theme.mdx",
     "fileName": "use-theme.mdx",
     "name": "use-theme",
     "path": "/native/hooks/use-theme",
@@ -1366,7 +1366,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/layout/field-stack.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/layout/field-stack.mdx",
     "fileName": "field-stack.mdx",
     "name": "field-stack",
     "path": "/native/layout/field-stack",
@@ -1381,7 +1381,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/layout/group.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/layout/group.mdx",
     "fileName": "group.mdx",
     "name": "group",
     "path": "/native/layout/group",
@@ -1392,7 +1392,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/layout/hide.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/layout/hide.mdx",
     "fileName": "hide.mdx",
     "name": "hide",
     "path": "/native/layout/hide",
@@ -1403,7 +1403,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/layout/level.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/layout/level.mdx",
     "fileName": "level.mdx",
     "name": "level",
     "path": "/native/layout/level",
@@ -1416,7 +1416,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/layout/set.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/layout/set.mdx",
     "fileName": "set.mdx",
     "name": "set",
     "path": "/native/layout/set",
@@ -1427,7 +1427,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/layout/show.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/layout/show.mdx",
     "fileName": "show.mdx",
     "name": "show",
     "path": "/native/layout/show",
@@ -1438,7 +1438,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/layout/stack.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/layout/stack.mdx",
     "fileName": "stack.mdx",
     "name": "stack",
     "path": "/native/layout/stack",
@@ -1449,7 +1449,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/palette.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/palette.mdx",
     "fileName": "palette.mdx",
     "name": "palette",
     "path": "/native/palette",
@@ -1464,7 +1464,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/platform-compatibility.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/platform-compatibility.mdx",
     "fileName": "platform-compatibility.mdx",
     "name": "platform-compatibility",
     "path": "/native/platform-compatibility",
@@ -1478,7 +1478,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/spacing.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/spacing.mdx",
     "fileName": "spacing.mdx",
     "name": "spacing",
     "path": "/native/spacing",
@@ -1493,7 +1493,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/styling-components.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/styling-components.mdx",
     "fileName": "styling-components.mdx",
     "name": "styling-components",
     "path": "/native/styling-components",
@@ -1508,7 +1508,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/alignment.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/alignment.mdx",
     "fileName": "alignment.mdx",
     "name": "alignment",
     "path": "/native/the-box-primitive/alignment",
@@ -1522,7 +1522,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/altitudes.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/altitudes.mdx",
     "fileName": "altitudes.mdx",
     "name": "altitudes",
     "path": "/native/the-box-primitive/altitudes",
@@ -1535,7 +1535,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/border-radius.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/border-radius.mdx",
     "fileName": "border-radius.mdx",
     "name": "border-radius",
     "path": "/native/the-box-primitive/border-radius",
@@ -1549,7 +1549,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/borders.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/borders.mdx",
     "fileName": "borders.mdx",
     "name": "borders",
     "path": "/native/the-box-primitive/borders",
@@ -1563,7 +1563,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/box-keyboardavoiding.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/box-keyboardavoiding.mdx",
     "fileName": "box-keyboardavoiding.mdx",
     "name": "box-keyboardavoiding",
     "path": "/native/the-box-primitive/box-keyboardavoiding",
@@ -1577,7 +1577,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/box-safe.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/box-safe.mdx",
     "fileName": "box-safe.mdx",
     "name": "box-safe",
     "path": "/native/the-box-primitive/box-safe",
@@ -1591,7 +1591,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/box-scroll.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/box-scroll.mdx",
     "fileName": "box-scroll.mdx",
     "name": "box-scroll",
     "path": "/native/the-box-primitive/box-scroll",
@@ -1605,7 +1605,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/box-touchable.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/box-touchable.mdx",
     "fileName": "box-touchable.mdx",
     "name": "box-touchable",
     "path": "/native/the-box-primitive/box-touchable",
@@ -1619,7 +1619,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/box-touchablewithoutfeedback.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/box-touchablewithoutfeedback.mdx",
     "fileName": "box-touchablewithoutfeedback.mdx",
     "name": "box-touchablewithoutfeedback",
     "path": "/native/the-box-primitive/box-touchablewithoutfeedback",
@@ -1633,7 +1633,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/box.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/box.mdx",
     "fileName": "box.mdx",
     "name": "box",
     "path": "/native/the-box-primitive/box",
@@ -1647,7 +1647,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/flex.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/flex.mdx",
     "fileName": "flex.mdx",
     "name": "flex",
     "path": "/native/the-box-primitive/flex",
@@ -1661,7 +1661,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/platform-styles.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/platform-styles.mdx",
     "fileName": "platform-styles.mdx",
     "name": "platform-styles",
     "path": "/native/the-box-primitive/platform-styles",
@@ -1675,7 +1675,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/pseudo-styles.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/pseudo-styles.mdx",
     "fileName": "pseudo-styles.mdx",
     "name": "pseudo-styles",
     "path": "/native/the-box-primitive/pseudo-styles",
@@ -1689,7 +1689,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/responsive-styles.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/responsive-styles.mdx",
     "fileName": "responsive-styles.mdx",
     "name": "responsive-styles",
     "path": "/native/the-box-primitive/responsive-styles",
@@ -1703,7 +1703,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/style-props.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/style-props.mdx",
     "fileName": "style-props.mdx",
     "name": "style-props",
     "path": "/native/the-box-primitive/style-props",
@@ -1717,7 +1717,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/theming.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/theming.mdx",
     "fileName": "theming.mdx",
     "name": "theming",
     "path": "/native/theming",
@@ -1732,7 +1732,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/typography/heading.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/typography/heading.mdx",
     "fileName": "heading.mdx",
     "name": "heading",
     "path": "/native/typography/heading",
@@ -1746,7 +1746,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/typography/link.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/typography/link.mdx",
     "fileName": "link.mdx",
     "name": "link",
     "path": "/native/typography/link",
@@ -1761,7 +1761,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/typography/list.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/typography/list.mdx",
     "fileName": "list.mdx",
     "name": "list",
     "path": "/native/typography/list",
@@ -1776,7 +1776,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/typography/text.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/typography/text.mdx",
     "fileName": "text.mdx",
     "name": "text",
     "path": "/native/typography/text",
@@ -1787,7 +1787,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/bottom-sheet-modal.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/bottom-sheet-modal.mdx",
     "fileName": "bottom-sheet-modal.mdx",
     "name": "bottom-sheet-modal",
     "path": "/native/utilities/bottom-sheet-modal",
@@ -1801,7 +1801,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/bottom-sheet.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/bottom-sheet.mdx",
     "fileName": "bottom-sheet.mdx",
     "name": "bottom-sheet",
     "path": "/native/utilities/bottom-sheet",
@@ -1815,7 +1815,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/drawer.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/drawer.mdx",
     "fileName": "drawer.mdx",
     "name": "drawer",
     "path": "/native/utilities/drawer",
@@ -1830,7 +1830,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/haptic.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/haptic.mdx",
     "fileName": "haptic.mdx",
     "name": "haptic",
     "path": "/native/utilities/haptic",
@@ -1844,7 +1844,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/hidden.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/hidden.mdx",
     "fileName": "hidden.mdx",
     "name": "hidden",
     "path": "/native/utilities/hidden",
@@ -1859,7 +1859,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/list.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/list.mdx",
     "fileName": "list.mdx",
     "name": "list",
     "path": "/native/utilities/list",
@@ -1870,7 +1870,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/modal.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/modal.mdx",
     "fileName": "modal.mdx",
     "name": "modal",
     "path": "/native/utilities/modal",
@@ -1885,7 +1885,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/overlay.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/overlay.mdx",
     "fileName": "overlay.mdx",
     "name": "overlay",
     "path": "/native/utilities/overlay",
@@ -1900,7 +1900,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/portal.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/portal.mdx",
     "fileName": "portal.mdx",
     "name": "portal",
     "path": "/native/utilities/portal",
@@ -1915,7 +1915,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/pressable.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/pressable.mdx",
     "fileName": "pressable.mdx",
     "name": "pressable",
     "path": "/native/utilities/pressable",
@@ -1929,7 +1929,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/refresh-control.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/refresh-control.mdx",
     "fileName": "refresh-control.mdx",
     "name": "refresh-control",
     "path": "/native/utilities/refresh-control",
@@ -1944,7 +1944,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/status-bar.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/status-bar.mdx",
     "fileName": "status-bar.mdx",
     "name": "status-bar",
     "path": "/native/utilities/status-bar",
@@ -1959,7 +1959,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/variants.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/variants.mdx",
     "fileName": "variants.mdx",
     "name": "variants",
     "path": "/native/variants",
@@ -1974,7 +1974,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/page-shells/intro.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/page-shells/intro.mdx",
     "fileName": "intro.mdx",
     "name": "intro",
     "path": "/page-shells/intro",
@@ -1988,7 +1988,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/page-shells/page-content.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/page-shells/page-content.mdx",
     "fileName": "page-content.mdx",
     "name": "page-content",
     "path": "/page-shells/page-content",
@@ -2001,7 +2001,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/page-shells/page-with-header.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/page-shells/page-with-header.mdx",
     "fileName": "page-with-header.mdx",
     "name": "page-with-header",
     "path": "/page-shells/page-with-header",
@@ -2012,7 +2012,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/page-shells/page-with-sidebar.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/page-shells/page-with-sidebar.mdx",
     "fileName": "page-with-sidebar.mdx",
     "name": "page-with-sidebar",
     "path": "/page-shells/page-with-sidebar",
@@ -2023,7 +2023,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/palette.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/palette.mdx",
     "fileName": "palette.mdx",
     "name": "palette",
     "path": "/palette",
@@ -2038,7 +2038,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/spacing.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/spacing.mdx",
     "fileName": "spacing.mdx",
     "name": "spacing",
     "path": "/spacing",
@@ -2053,7 +2053,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/styling-components.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/styling-components.mdx",
     "fileName": "styling-components.mdx",
     "name": "styling-components",
     "path": "/styling-components",
@@ -2068,7 +2068,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/alignment.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/alignment.mdx",
     "fileName": "alignment.mdx",
     "name": "alignment",
     "path": "/the-box-primitive/alignment",
@@ -2082,7 +2082,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/altitudes.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/altitudes.mdx",
     "fileName": "altitudes.mdx",
     "name": "altitudes",
     "path": "/the-box-primitive/altitudes",
@@ -2095,7 +2095,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/border-radius.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/border-radius.mdx",
     "fileName": "border-radius.mdx",
     "name": "border-radius",
     "path": "/the-box-primitive/border-radius",
@@ -2109,7 +2109,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/borders.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/borders.mdx",
     "fileName": "borders.mdx",
     "name": "borders",
     "path": "/the-box-primitive/borders",
@@ -2123,7 +2123,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/box.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/box.mdx",
     "fileName": "box.mdx",
     "name": "box",
     "path": "/the-box-primitive/box",
@@ -2137,7 +2137,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/flex.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/flex.mdx",
     "fileName": "flex.mdx",
     "name": "flex",
     "path": "/the-box-primitive/flex",
@@ -2151,7 +2151,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/gradients.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/gradients.mdx",
     "fileName": "gradients.mdx",
     "name": "gradients",
     "path": "/the-box-primitive/gradients",
@@ -2162,7 +2162,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/pseudo-selectors.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/pseudo-selectors.mdx",
     "fileName": "pseudo-selectors.mdx",
     "name": "pseudo-selectors",
     "path": "/the-box-primitive/pseudo-selectors",
@@ -2176,7 +2176,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/responsive-styles.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/responsive-styles.mdx",
     "fileName": "responsive-styles.mdx",
     "name": "responsive-styles",
     "path": "/the-box-primitive/responsive-styles",
@@ -2190,7 +2190,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/style-props.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/style-props.mdx",
     "fileName": "style-props.mdx",
     "name": "style-props",
     "path": "/the-box-primitive/style-props",
@@ -2204,7 +2204,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/theming.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/theming.mdx",
     "fileName": "theming.mdx",
     "name": "theming",
     "path": "/theming",
@@ -2219,7 +2219,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/typography/blockquote.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/typography/blockquote.mdx",
     "fileName": "blockquote.mdx",
     "name": "blockquote",
     "path": "/typography/blockquote",
@@ -2230,7 +2230,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/typography/code.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/typography/code.mdx",
     "fileName": "code.mdx",
     "name": "code",
     "path": "/typography/code",
@@ -2241,7 +2241,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/typography/heading.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/typography/heading.mdx",
     "fileName": "heading.mdx",
     "name": "heading",
     "path": "/typography/heading",
@@ -2252,7 +2252,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/typography/link.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/typography/link.mdx",
     "fileName": "link.mdx",
     "name": "link",
     "path": "/typography/link",
@@ -2263,7 +2263,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/typography/list.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/typography/list.mdx",
     "fileName": "list.mdx",
     "name": "list",
     "path": "/typography/list",
@@ -2274,7 +2274,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/typography/paragraph.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/typography/paragraph.mdx",
     "fileName": "paragraph.mdx",
     "name": "paragraph",
     "path": "/typography/paragraph",
@@ -2285,7 +2285,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/typography/text.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/typography/text.mdx",
     "fileName": "text.mdx",
     "name": "text",
     "path": "/typography/text",
@@ -2296,7 +2296,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/utilities/clickable.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/utilities/clickable.mdx",
     "fileName": "clickable.mdx",
     "name": "clickable",
     "path": "/utilities/clickable",
@@ -2307,7 +2307,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/utilities/disclosure.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/utilities/disclosure.mdx",
     "fileName": "disclosure.mdx",
     "name": "disclosure",
     "path": "/utilities/disclosure",
@@ -2318,7 +2318,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/utilities/drawer.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/utilities/drawer.mdx",
     "fileName": "drawer.mdx",
     "name": "drawer",
     "path": "/utilities/drawer",
@@ -2329,7 +2329,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/utilities/modal.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/utilities/modal.mdx",
     "fileName": "modal.mdx",
     "name": "modal",
     "path": "/utilities/modal",
@@ -2340,7 +2340,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/utilities/overlay.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/utilities/overlay.mdx",
     "fileName": "overlay.mdx",
     "name": "overlay",
     "path": "/utilities/overlay",
@@ -2351,7 +2351,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/utilities/portal.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/utilities/portal.mdx",
     "fileName": "portal.mdx",
     "name": "portal",
     "path": "/utilities/portal",
@@ -2362,7 +2362,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/utilities/rover.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/utilities/rover.mdx",
     "fileName": "rover.mdx",
     "name": "rover",
     "path": "/utilities/rover",
@@ -2373,7 +2373,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/utilities/tabbable.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/utilities/tabbable.mdx",
     "fileName": "tabbable.mdx",
     "name": "tabbable",
     "path": "/utilities/tabbable",
@@ -2384,7 +2384,7 @@
     }
   },
   {
-    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/variants.mdx",
+    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/variants.mdx",
     "fileName": "variants.mdx",
     "name": "variants",
     "path": "/variants",

--- a/website/mdx-manifest.json
+++ b/website/mdx-manifest.json
@@ -1,6 +1,6 @@
 [
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/addons/highlighted-code.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/addons/highlighted-code.mdx",
     "fileName": "highlighted-code.mdx",
     "name": "highlighted-code",
     "path": "/addons/highlighted-code",
@@ -11,7 +11,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/addons/markdown.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/addons/markdown.mdx",
     "fileName": "markdown.mdx",
     "name": "markdown",
     "path": "/addons/markdown",
@@ -22,7 +22,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/blocks/hero.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/blocks/hero.mdx",
     "fileName": "hero.mdx",
     "name": "hero",
     "path": "/blocks/hero",
@@ -37,7 +37,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/breakpoints.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/breakpoints.mdx",
     "fileName": "breakpoints.mdx",
     "name": "breakpoints",
     "path": "/breakpoints",
@@ -52,7 +52,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/color-modes.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/color-modes.mdx",
     "fileName": "color-modes.mdx",
     "name": "color-modes",
     "path": "/color-modes",
@@ -67,7 +67,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/action-buttons.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/action-buttons.mdx",
     "fileName": "action-buttons.mdx",
     "name": "action-buttons",
     "path": "/components/action-buttons",
@@ -78,7 +78,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/alert.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/alert.mdx",
     "fileName": "alert.mdx",
     "name": "alert",
     "path": "/components/alert",
@@ -89,7 +89,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/avatar.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/avatar.mdx",
     "fileName": "avatar.mdx",
     "name": "avatar",
     "path": "/components/avatar",
@@ -100,7 +100,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/badge.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/badge.mdx",
     "fileName": "badge.mdx",
     "name": "badge",
     "path": "/components/badge",
@@ -111,7 +111,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/breadcrumb.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/breadcrumb.mdx",
     "fileName": "breadcrumb.mdx",
     "name": "breadcrumb",
     "path": "/components/breadcrumb",
@@ -122,7 +122,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/button.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/button.mdx",
     "fileName": "button.mdx",
     "name": "button",
     "path": "/components/button",
@@ -133,7 +133,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/callout.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/callout.mdx",
     "fileName": "callout.mdx",
     "name": "callout",
     "path": "/components/callout",
@@ -144,7 +144,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/card.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/card.mdx",
     "fileName": "card.mdx",
     "name": "card",
     "path": "/components/card",
@@ -155,7 +155,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/dialog.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/dialog.mdx",
     "fileName": "dialog.mdx",
     "name": "dialog",
     "path": "/components/dialog",
@@ -166,7 +166,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/divider.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/divider.mdx",
     "fileName": "divider.mdx",
     "name": "divider",
     "path": "/components/divider",
@@ -177,7 +177,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/dropdown-menu.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/dropdown-menu.mdx",
     "fileName": "dropdown-menu.mdx",
     "name": "dropdown-menu",
     "path": "/components/dropdown-menu",
@@ -188,7 +188,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/icon.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/icon.mdx",
     "fileName": "icon.mdx",
     "name": "icon",
     "path": "/components/icon",
@@ -199,7 +199,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/image.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/image.mdx",
     "fileName": "image.mdx",
     "name": "image",
     "path": "/components/image",
@@ -210,7 +210,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/key.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/key.mdx",
     "fileName": "key.mdx",
     "name": "key",
     "path": "/components/key",
@@ -221,7 +221,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/menu.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/menu.mdx",
     "fileName": "menu.mdx",
     "name": "menu",
     "path": "/components/menu",
@@ -232,7 +232,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/navigation.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/navigation.mdx",
     "fileName": "navigation.mdx",
     "name": "navigation",
     "path": "/components/navigation",
@@ -243,7 +243,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/pagination.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/pagination.mdx",
     "fileName": "pagination.mdx",
     "name": "pagination",
     "path": "/components/pagination",
@@ -254,7 +254,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/popover.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/popover.mdx",
     "fileName": "popover.mdx",
     "name": "popover",
     "path": "/components/popover",
@@ -265,7 +265,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/progress-bar.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/progress-bar.mdx",
     "fileName": "progress-bar.mdx",
     "name": "progress-bar",
     "path": "/components/progress-bar",
@@ -276,7 +276,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/rating.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/rating.mdx",
     "fileName": "rating.mdx",
     "name": "rating",
     "path": "/components/rating",
@@ -287,7 +287,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/side-nav.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/side-nav.mdx",
     "fileName": "side-nav.mdx",
     "name": "side-nav",
     "path": "/components/side-nav",
@@ -298,7 +298,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/spinner.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/spinner.mdx",
     "fileName": "spinner.mdx",
     "name": "spinner",
     "path": "/components/spinner",
@@ -309,7 +309,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/table.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/table.mdx",
     "fileName": "table.mdx",
     "name": "table",
     "path": "/components/table",
@@ -320,7 +320,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/tabs.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/tabs.mdx",
     "fileName": "tabs.mdx",
     "name": "tabs",
     "path": "/components/tabs",
@@ -331,7 +331,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/tag.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/tag.mdx",
     "fileName": "tag.mdx",
     "name": "tag",
     "path": "/components/tag",
@@ -342,7 +342,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/toast.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/toast.mdx",
     "fileName": "toast.mdx",
     "name": "toast",
     "path": "/components/toast",
@@ -353,7 +353,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/tooltip.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/tooltip.mdx",
     "fileName": "tooltip.mdx",
     "name": "tooltip",
     "path": "/components/tooltip",
@@ -364,7 +364,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/components/top-nav.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/components/top-nav.mdx",
     "fileName": "top-nav.mdx",
     "name": "top-nav",
     "path": "/components/top-nav",
@@ -375,7 +375,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/composition.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/composition.mdx",
     "fileName": "composition.mdx",
     "name": "composition",
     "path": "/composition",
@@ -390,7 +390,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/fonts.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/fonts.mdx",
     "fileName": "fonts.mdx",
     "name": "fonts",
     "path": "/fonts",
@@ -404,7 +404,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/autosuggest.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/autosuggest.mdx",
     "fileName": "autosuggest.mdx",
     "name": "autosuggest",
     "path": "/form/autosuggest",
@@ -415,7 +415,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/checkbox-group.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/checkbox-group.mdx",
     "fileName": "checkbox-group.mdx",
     "name": "checkbox-group",
     "path": "/form/checkbox-group",
@@ -426,7 +426,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/checkbox.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/checkbox.mdx",
     "fileName": "checkbox.mdx",
     "name": "checkbox",
     "path": "/form/checkbox",
@@ -437,7 +437,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/field-stack.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/field-stack.mdx",
     "fileName": "field-stack.mdx",
     "name": "field-stack",
     "path": "/form/field-stack",
@@ -448,7 +448,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/field-wrapper.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/field-wrapper.mdx",
     "fileName": "field-wrapper.mdx",
     "name": "field-wrapper",
     "path": "/form/field-wrapper",
@@ -459,7 +459,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/form-libraries.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/form-libraries.mdx",
     "fileName": "form-libraries.mdx",
     "name": "form-libraries",
     "path": "/form/form-libraries",
@@ -472,7 +472,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/input.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/input.mdx",
     "fileName": "input.mdx",
     "name": "input",
     "path": "/form/input",
@@ -483,7 +483,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/label.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/label.mdx",
     "fileName": "label.mdx",
     "name": "label",
     "path": "/form/label",
@@ -494,7 +494,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/option-buttons.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/option-buttons.mdx",
     "fileName": "option-buttons.mdx",
     "name": "option-buttons",
     "path": "/form/option-buttons",
@@ -505,7 +505,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/radio-group.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/radio-group.mdx",
     "fileName": "radio-group.mdx",
     "name": "radio-group",
     "path": "/form/radio-group",
@@ -516,7 +516,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/radio.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/radio.mdx",
     "fileName": "radio.mdx",
     "name": "radio",
     "path": "/form/radio",
@@ -527,7 +527,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/select-menu.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/select-menu.mdx",
     "fileName": "select-menu.mdx",
     "name": "select-menu",
     "path": "/form/select-menu",
@@ -538,7 +538,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/select.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/select.mdx",
     "fileName": "select.mdx",
     "name": "select",
     "path": "/form/select",
@@ -549,7 +549,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/switch-group.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/switch-group.mdx",
     "fileName": "switch-group.mdx",
     "name": "switch-group",
     "path": "/form/switch-group",
@@ -560,7 +560,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/switch.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/switch.mdx",
     "fileName": "switch.mdx",
     "name": "switch",
     "path": "/form/switch",
@@ -571,7 +571,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/form/textarea.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/form/textarea.mdx",
     "fileName": "textarea.mdx",
     "name": "textarea",
     "path": "/form/textarea",
@@ -582,7 +582,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/getting-started.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/getting-started.mdx",
     "fileName": "getting-started.mdx",
     "name": "getting-started",
     "path": "/getting-started",
@@ -596,7 +596,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/global-styles.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/global-styles.mdx",
     "fileName": "global-styles.mdx",
     "name": "global-styles",
     "path": "/global-styles",
@@ -611,7 +611,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/hooks/use-breakpoint-value.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/hooks/use-breakpoint-value.mdx",
     "fileName": "use-breakpoint-value.mdx",
     "name": "use-breakpoint-value",
     "path": "/hooks/use-breakpoint-value",
@@ -625,7 +625,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/hooks/use-breakpoint.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/hooks/use-breakpoint.mdx",
     "fileName": "use-breakpoint.mdx",
     "name": "use-breakpoint",
     "path": "/hooks/use-breakpoint",
@@ -639,7 +639,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/hooks/use-page.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/hooks/use-page.mdx",
     "fileName": "use-page.mdx",
     "name": "use-page",
     "path": "/hooks/use-page",
@@ -653,7 +653,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/hooks/use-theme.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/hooks/use-theme.mdx",
     "fileName": "use-theme.mdx",
     "name": "use-theme",
     "path": "/hooks/use-theme",
@@ -667,7 +667,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/layout/columns.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/layout/columns.mdx",
     "fileName": "columns.mdx",
     "name": "columns",
     "path": "/layout/columns",
@@ -678,7 +678,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/layout/container.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/layout/container.mdx",
     "fileName": "container.mdx",
     "name": "container",
     "path": "/layout/container",
@@ -691,7 +691,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/layout/group.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/layout/group.mdx",
     "fileName": "group.mdx",
     "name": "group",
     "path": "/layout/group",
@@ -702,7 +702,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/layout/hide.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/layout/hide.mdx",
     "fileName": "hide.mdx",
     "name": "hide",
     "path": "/layout/hide",
@@ -713,7 +713,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/layout/level.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/layout/level.mdx",
     "fileName": "level.mdx",
     "name": "level",
     "path": "/layout/level",
@@ -726,7 +726,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/layout/set.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/layout/set.mdx",
     "fileName": "set.mdx",
     "name": "set",
     "path": "/layout/set",
@@ -737,7 +737,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/layout/show.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/layout/show.mdx",
     "fileName": "show.mdx",
     "name": "show",
     "path": "/layout/show",
@@ -748,7 +748,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/layout/stack.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/layout/stack.mdx",
     "fileName": "stack.mdx",
     "name": "stack",
     "path": "/layout/stack",
@@ -759,7 +759,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/migrating-from-fannypack.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/migrating-from-fannypack.mdx",
     "fileName": "migrating-from-fannypack.mdx",
     "name": "migrating-from-fannypack",
     "path": "/migrating-from-fannypack",
@@ -774,7 +774,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/breakpoints.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/breakpoints.mdx",
     "fileName": "breakpoints.mdx",
     "name": "breakpoints",
     "path": "/native/breakpoints",
@@ -788,7 +788,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/color-modes.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/color-modes.mdx",
     "fileName": "color-modes.mdx",
     "name": "color-modes",
     "path": "/native/color-modes",
@@ -803,7 +803,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/action-buttons.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/action-buttons.mdx",
     "fileName": "action-buttons.mdx",
     "name": "action-buttons",
     "path": "/native/components/action-buttons",
@@ -818,7 +818,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/alert.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/alert.mdx",
     "fileName": "alert.mdx",
     "name": "alert",
     "path": "/native/components/alert",
@@ -833,7 +833,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/avatar.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/avatar.mdx",
     "fileName": "avatar.mdx",
     "name": "avatar",
     "path": "/native/components/avatar",
@@ -848,7 +848,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/badge.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/badge.mdx",
     "fileName": "badge.mdx",
     "name": "badge",
     "path": "/native/components/badge",
@@ -863,7 +863,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/bottom-nav.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/bottom-nav.mdx",
     "fileName": "bottom-nav.mdx",
     "name": "bottom-nav",
     "path": "/native/components/bottom-nav",
@@ -878,7 +878,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/button.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/button.mdx",
     "fileName": "button.mdx",
     "name": "button",
     "path": "/native/components/button",
@@ -891,7 +891,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/card.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/card.mdx",
     "fileName": "card.mdx",
     "name": "card",
     "path": "/native/components/card",
@@ -906,7 +906,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/dialog-alert.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/dialog-alert.mdx",
     "fileName": "dialog-alert.mdx",
     "name": "dialog-alert",
     "path": "/native/components/dialog-alert",
@@ -921,7 +921,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/dialog.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/dialog.mdx",
     "fileName": "dialog.mdx",
     "name": "dialog",
     "path": "/native/components/dialog",
@@ -936,7 +936,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/divider.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/divider.mdx",
     "fileName": "divider.mdx",
     "name": "divider",
     "path": "/native/components/divider",
@@ -951,7 +951,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/dropdown-menu.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/dropdown-menu.mdx",
     "fileName": "dropdown-menu.mdx",
     "name": "dropdown-menu",
     "path": "/native/components/dropdown-menu",
@@ -966,7 +966,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/fab.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/fab.mdx",
     "fileName": "fab.mdx",
     "name": "fab",
     "path": "/native/components/fab",
@@ -981,7 +981,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/icon.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/icon.mdx",
     "fileName": "icon.mdx",
     "name": "icon",
     "path": "/native/components/icon",
@@ -992,7 +992,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/image.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/image.mdx",
     "fileName": "image.mdx",
     "name": "image",
     "path": "/native/components/image",
@@ -1003,7 +1003,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/menu.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/menu.mdx",
     "fileName": "menu.mdx",
     "name": "menu",
     "path": "/native/components/menu",
@@ -1017,7 +1017,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/popover.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/popover.mdx",
     "fileName": "popover.mdx",
     "name": "popover",
     "path": "/native/components/popover",
@@ -1032,7 +1032,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/progress-bar.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/progress-bar.mdx",
     "fileName": "progress-bar.mdx",
     "name": "progress-bar",
     "path": "/native/components/progress-bar",
@@ -1047,7 +1047,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/rating.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/rating.mdx",
     "fileName": "rating.mdx",
     "name": "rating",
     "path": "/native/components/rating",
@@ -1062,7 +1062,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/search-bar.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/search-bar.mdx",
     "fileName": "search-bar.mdx",
     "name": "search-bar",
     "path": "/native/components/search-bar",
@@ -1077,7 +1077,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/spinner.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/spinner.mdx",
     "fileName": "spinner.mdx",
     "name": "spinner",
     "path": "/native/components/spinner",
@@ -1088,7 +1088,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/tabs.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/tabs.mdx",
     "fileName": "tabs.mdx",
     "name": "tabs",
     "path": "/native/components/tabs",
@@ -1103,7 +1103,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/tag.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/tag.mdx",
     "fileName": "tag.mdx",
     "name": "tag",
     "path": "/native/components/tag",
@@ -1118,7 +1118,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/toast.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/toast.mdx",
     "fileName": "toast.mdx",
     "name": "toast",
     "path": "/native/components/toast",
@@ -1132,7 +1132,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/tooltip.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/tooltip.mdx",
     "fileName": "tooltip.mdx",
     "name": "tooltip",
     "path": "/native/components/tooltip",
@@ -1147,7 +1147,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/components/top-nav.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/components/top-nav.mdx",
     "fileName": "top-nav.mdx",
     "name": "top-nav",
     "path": "/native/components/top-nav",
@@ -1162,7 +1162,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/fonts.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/fonts.mdx",
     "fileName": "fonts.mdx",
     "name": "fonts",
     "path": "/native/fonts",
@@ -1177,7 +1177,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/autosuggest.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/autosuggest.mdx",
     "fileName": "autosuggest.mdx",
     "name": "autosuggest",
     "path": "/native/form/autosuggest",
@@ -1192,7 +1192,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/checkbox-group.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/checkbox-group.mdx",
     "fileName": "checkbox-group.mdx",
     "name": "checkbox-group",
     "path": "/native/form/checkbox-group",
@@ -1203,7 +1203,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/checkbox.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/checkbox.mdx",
     "fileName": "checkbox.mdx",
     "name": "checkbox",
     "path": "/native/form/checkbox",
@@ -1214,7 +1214,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/field-wrapper.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/field-wrapper.mdx",
     "fileName": "field-wrapper.mdx",
     "name": "field-wrapper",
     "path": "/native/form/field-wrapper",
@@ -1225,7 +1225,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/input.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/input.mdx",
     "fileName": "input.mdx",
     "name": "input",
     "path": "/native/form/input",
@@ -1236,7 +1236,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/picker.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/picker.mdx",
     "fileName": "picker.mdx",
     "name": "picker",
     "path": "/native/form/picker",
@@ -1250,7 +1250,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/radio-group.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/radio-group.mdx",
     "fileName": "radio-group.mdx",
     "name": "radio-group",
     "path": "/native/form/radio-group",
@@ -1261,7 +1261,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/radio.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/radio.mdx",
     "fileName": "radio.mdx",
     "name": "radio",
     "path": "/native/form/radio",
@@ -1272,7 +1272,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/select.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/select.mdx",
     "fileName": "select.mdx",
     "name": "select",
     "path": "/native/form/select",
@@ -1287,7 +1287,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/switch-group.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/switch-group.mdx",
     "fileName": "switch-group.mdx",
     "name": "switch-group",
     "path": "/native/form/switch-group",
@@ -1298,7 +1298,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/switch.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/switch.mdx",
     "fileName": "switch.mdx",
     "name": "switch",
     "path": "/native/form/switch",
@@ -1309,7 +1309,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/form/textarea.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/form/textarea.mdx",
     "fileName": "textarea.mdx",
     "name": "textarea",
     "path": "/native/form/textarea",
@@ -1324,7 +1324,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/getting-started.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/getting-started.mdx",
     "fileName": "getting-started.mdx",
     "name": "getting-started",
     "path": "/native/getting-started",
@@ -1338,7 +1338,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/hooks/use-breakpoint.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/hooks/use-breakpoint.mdx",
     "fileName": "use-breakpoint.mdx",
     "name": "use-breakpoint",
     "path": "/native/hooks/use-breakpoint",
@@ -1352,7 +1352,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/hooks/use-theme.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/hooks/use-theme.mdx",
     "fileName": "use-theme.mdx",
     "name": "use-theme",
     "path": "/native/hooks/use-theme",
@@ -1366,7 +1366,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/layout/field-stack.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/layout/field-stack.mdx",
     "fileName": "field-stack.mdx",
     "name": "field-stack",
     "path": "/native/layout/field-stack",
@@ -1381,7 +1381,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/layout/group.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/layout/group.mdx",
     "fileName": "group.mdx",
     "name": "group",
     "path": "/native/layout/group",
@@ -1392,7 +1392,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/layout/hide.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/layout/hide.mdx",
     "fileName": "hide.mdx",
     "name": "hide",
     "path": "/native/layout/hide",
@@ -1403,7 +1403,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/layout/level.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/layout/level.mdx",
     "fileName": "level.mdx",
     "name": "level",
     "path": "/native/layout/level",
@@ -1416,7 +1416,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/layout/set.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/layout/set.mdx",
     "fileName": "set.mdx",
     "name": "set",
     "path": "/native/layout/set",
@@ -1427,7 +1427,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/layout/show.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/layout/show.mdx",
     "fileName": "show.mdx",
     "name": "show",
     "path": "/native/layout/show",
@@ -1438,7 +1438,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/layout/stack.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/layout/stack.mdx",
     "fileName": "stack.mdx",
     "name": "stack",
     "path": "/native/layout/stack",
@@ -1449,7 +1449,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/palette.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/palette.mdx",
     "fileName": "palette.mdx",
     "name": "palette",
     "path": "/native/palette",
@@ -1464,7 +1464,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/platform-compatibility.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/platform-compatibility.mdx",
     "fileName": "platform-compatibility.mdx",
     "name": "platform-compatibility",
     "path": "/native/platform-compatibility",
@@ -1478,7 +1478,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/spacing.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/spacing.mdx",
     "fileName": "spacing.mdx",
     "name": "spacing",
     "path": "/native/spacing",
@@ -1493,7 +1493,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/styling-components.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/styling-components.mdx",
     "fileName": "styling-components.mdx",
     "name": "styling-components",
     "path": "/native/styling-components",
@@ -1508,7 +1508,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/alignment.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/alignment.mdx",
     "fileName": "alignment.mdx",
     "name": "alignment",
     "path": "/native/the-box-primitive/alignment",
@@ -1522,7 +1522,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/altitudes.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/altitudes.mdx",
     "fileName": "altitudes.mdx",
     "name": "altitudes",
     "path": "/native/the-box-primitive/altitudes",
@@ -1535,7 +1535,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/border-radius.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/border-radius.mdx",
     "fileName": "border-radius.mdx",
     "name": "border-radius",
     "path": "/native/the-box-primitive/border-radius",
@@ -1549,7 +1549,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/borders.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/borders.mdx",
     "fileName": "borders.mdx",
     "name": "borders",
     "path": "/native/the-box-primitive/borders",
@@ -1563,7 +1563,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/box-keyboardavoiding.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/box-keyboardavoiding.mdx",
     "fileName": "box-keyboardavoiding.mdx",
     "name": "box-keyboardavoiding",
     "path": "/native/the-box-primitive/box-keyboardavoiding",
@@ -1577,7 +1577,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/box-safe.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/box-safe.mdx",
     "fileName": "box-safe.mdx",
     "name": "box-safe",
     "path": "/native/the-box-primitive/box-safe",
@@ -1591,7 +1591,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/box-scroll.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/box-scroll.mdx",
     "fileName": "box-scroll.mdx",
     "name": "box-scroll",
     "path": "/native/the-box-primitive/box-scroll",
@@ -1605,7 +1605,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/box-touchable.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/box-touchable.mdx",
     "fileName": "box-touchable.mdx",
     "name": "box-touchable",
     "path": "/native/the-box-primitive/box-touchable",
@@ -1619,7 +1619,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/box-touchablewithoutfeedback.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/box-touchablewithoutfeedback.mdx",
     "fileName": "box-touchablewithoutfeedback.mdx",
     "name": "box-touchablewithoutfeedback",
     "path": "/native/the-box-primitive/box-touchablewithoutfeedback",
@@ -1633,7 +1633,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/box.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/box.mdx",
     "fileName": "box.mdx",
     "name": "box",
     "path": "/native/the-box-primitive/box",
@@ -1647,7 +1647,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/flex.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/flex.mdx",
     "fileName": "flex.mdx",
     "name": "flex",
     "path": "/native/the-box-primitive/flex",
@@ -1661,7 +1661,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/platform-styles.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/platform-styles.mdx",
     "fileName": "platform-styles.mdx",
     "name": "platform-styles",
     "path": "/native/the-box-primitive/platform-styles",
@@ -1675,7 +1675,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/pseudo-styles.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/pseudo-styles.mdx",
     "fileName": "pseudo-styles.mdx",
     "name": "pseudo-styles",
     "path": "/native/the-box-primitive/pseudo-styles",
@@ -1689,7 +1689,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/responsive-styles.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/responsive-styles.mdx",
     "fileName": "responsive-styles.mdx",
     "name": "responsive-styles",
     "path": "/native/the-box-primitive/responsive-styles",
@@ -1703,7 +1703,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/the-box-primitive/style-props.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/the-box-primitive/style-props.mdx",
     "fileName": "style-props.mdx",
     "name": "style-props",
     "path": "/native/the-box-primitive/style-props",
@@ -1717,7 +1717,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/theming.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/theming.mdx",
     "fileName": "theming.mdx",
     "name": "theming",
     "path": "/native/theming",
@@ -1732,7 +1732,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/typography/heading.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/typography/heading.mdx",
     "fileName": "heading.mdx",
     "name": "heading",
     "path": "/native/typography/heading",
@@ -1746,7 +1746,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/typography/link.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/typography/link.mdx",
     "fileName": "link.mdx",
     "name": "link",
     "path": "/native/typography/link",
@@ -1761,7 +1761,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/typography/list.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/typography/list.mdx",
     "fileName": "list.mdx",
     "name": "list",
     "path": "/native/typography/list",
@@ -1776,7 +1776,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/typography/text.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/typography/text.mdx",
     "fileName": "text.mdx",
     "name": "text",
     "path": "/native/typography/text",
@@ -1787,7 +1787,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/bottom-sheet-modal.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/bottom-sheet-modal.mdx",
     "fileName": "bottom-sheet-modal.mdx",
     "name": "bottom-sheet-modal",
     "path": "/native/utilities/bottom-sheet-modal",
@@ -1801,7 +1801,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/bottom-sheet.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/bottom-sheet.mdx",
     "fileName": "bottom-sheet.mdx",
     "name": "bottom-sheet",
     "path": "/native/utilities/bottom-sheet",
@@ -1815,7 +1815,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/drawer.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/drawer.mdx",
     "fileName": "drawer.mdx",
     "name": "drawer",
     "path": "/native/utilities/drawer",
@@ -1830,7 +1830,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/haptic.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/haptic.mdx",
     "fileName": "haptic.mdx",
     "name": "haptic",
     "path": "/native/utilities/haptic",
@@ -1844,7 +1844,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/hidden.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/hidden.mdx",
     "fileName": "hidden.mdx",
     "name": "hidden",
     "path": "/native/utilities/hidden",
@@ -1859,7 +1859,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/list.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/list.mdx",
     "fileName": "list.mdx",
     "name": "list",
     "path": "/native/utilities/list",
@@ -1870,7 +1870,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/modal.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/modal.mdx",
     "fileName": "modal.mdx",
     "name": "modal",
     "path": "/native/utilities/modal",
@@ -1885,7 +1885,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/overlay.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/overlay.mdx",
     "fileName": "overlay.mdx",
     "name": "overlay",
     "path": "/native/utilities/overlay",
@@ -1900,7 +1900,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/portal.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/portal.mdx",
     "fileName": "portal.mdx",
     "name": "portal",
     "path": "/native/utilities/portal",
@@ -1915,7 +1915,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/pressable.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/pressable.mdx",
     "fileName": "pressable.mdx",
     "name": "pressable",
     "path": "/native/utilities/pressable",
@@ -1929,7 +1929,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/refresh-control.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/refresh-control.mdx",
     "fileName": "refresh-control.mdx",
     "name": "refresh-control",
     "path": "/native/utilities/refresh-control",
@@ -1944,7 +1944,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/utilities/status-bar.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/utilities/status-bar.mdx",
     "fileName": "status-bar.mdx",
     "name": "status-bar",
     "path": "/native/utilities/status-bar",
@@ -1959,7 +1959,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/native/variants.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/native/variants.mdx",
     "fileName": "variants.mdx",
     "name": "variants",
     "path": "/native/variants",
@@ -1974,7 +1974,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/page-shells/intro.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/page-shells/intro.mdx",
     "fileName": "intro.mdx",
     "name": "intro",
     "path": "/page-shells/intro",
@@ -1988,7 +1988,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/page-shells/page-content.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/page-shells/page-content.mdx",
     "fileName": "page-content.mdx",
     "name": "page-content",
     "path": "/page-shells/page-content",
@@ -2001,7 +2001,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/page-shells/page-with-header.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/page-shells/page-with-header.mdx",
     "fileName": "page-with-header.mdx",
     "name": "page-with-header",
     "path": "/page-shells/page-with-header",
@@ -2012,7 +2012,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/page-shells/page-with-sidebar.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/page-shells/page-with-sidebar.mdx",
     "fileName": "page-with-sidebar.mdx",
     "name": "page-with-sidebar",
     "path": "/page-shells/page-with-sidebar",
@@ -2023,7 +2023,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/palette.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/palette.mdx",
     "fileName": "palette.mdx",
     "name": "palette",
     "path": "/palette",
@@ -2038,7 +2038,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/spacing.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/spacing.mdx",
     "fileName": "spacing.mdx",
     "name": "spacing",
     "path": "/spacing",
@@ -2053,7 +2053,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/styling-components.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/styling-components.mdx",
     "fileName": "styling-components.mdx",
     "name": "styling-components",
     "path": "/styling-components",
@@ -2068,7 +2068,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/alignment.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/alignment.mdx",
     "fileName": "alignment.mdx",
     "name": "alignment",
     "path": "/the-box-primitive/alignment",
@@ -2082,7 +2082,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/altitudes.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/altitudes.mdx",
     "fileName": "altitudes.mdx",
     "name": "altitudes",
     "path": "/the-box-primitive/altitudes",
@@ -2095,7 +2095,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/border-radius.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/border-radius.mdx",
     "fileName": "border-radius.mdx",
     "name": "border-radius",
     "path": "/the-box-primitive/border-radius",
@@ -2109,7 +2109,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/borders.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/borders.mdx",
     "fileName": "borders.mdx",
     "name": "borders",
     "path": "/the-box-primitive/borders",
@@ -2123,7 +2123,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/box.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/box.mdx",
     "fileName": "box.mdx",
     "name": "box",
     "path": "/the-box-primitive/box",
@@ -2137,7 +2137,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/flex.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/flex.mdx",
     "fileName": "flex.mdx",
     "name": "flex",
     "path": "/the-box-primitive/flex",
@@ -2151,7 +2151,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/gradients.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/gradients.mdx",
     "fileName": "gradients.mdx",
     "name": "gradients",
     "path": "/the-box-primitive/gradients",
@@ -2162,7 +2162,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/pseudo-selectors.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/pseudo-selectors.mdx",
     "fileName": "pseudo-selectors.mdx",
     "name": "pseudo-selectors",
     "path": "/the-box-primitive/pseudo-selectors",
@@ -2176,7 +2176,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/responsive-styles.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/responsive-styles.mdx",
     "fileName": "responsive-styles.mdx",
     "name": "responsive-styles",
     "path": "/the-box-primitive/responsive-styles",
@@ -2190,7 +2190,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/the-box-primitive/style-props.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/the-box-primitive/style-props.mdx",
     "fileName": "style-props.mdx",
     "name": "style-props",
     "path": "/the-box-primitive/style-props",
@@ -2204,7 +2204,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/theming.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/theming.mdx",
     "fileName": "theming.mdx",
     "name": "theming",
     "path": "/theming",
@@ -2219,7 +2219,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/typography/blockquote.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/typography/blockquote.mdx",
     "fileName": "blockquote.mdx",
     "name": "blockquote",
     "path": "/typography/blockquote",
@@ -2230,7 +2230,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/typography/code.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/typography/code.mdx",
     "fileName": "code.mdx",
     "name": "code",
     "path": "/typography/code",
@@ -2241,7 +2241,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/typography/heading.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/typography/heading.mdx",
     "fileName": "heading.mdx",
     "name": "heading",
     "path": "/typography/heading",
@@ -2252,7 +2252,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/typography/link.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/typography/link.mdx",
     "fileName": "link.mdx",
     "name": "link",
     "path": "/typography/link",
@@ -2263,7 +2263,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/typography/list.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/typography/list.mdx",
     "fileName": "list.mdx",
     "name": "list",
     "path": "/typography/list",
@@ -2274,7 +2274,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/typography/paragraph.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/typography/paragraph.mdx",
     "fileName": "paragraph.mdx",
     "name": "paragraph",
     "path": "/typography/paragraph",
@@ -2285,7 +2285,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/typography/text.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/typography/text.mdx",
     "fileName": "text.mdx",
     "name": "text",
     "path": "/typography/text",
@@ -2296,7 +2296,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/utilities/clickable.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/utilities/clickable.mdx",
     "fileName": "clickable.mdx",
     "name": "clickable",
     "path": "/utilities/clickable",
@@ -2307,7 +2307,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/utilities/disclosure.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/utilities/disclosure.mdx",
     "fileName": "disclosure.mdx",
     "name": "disclosure",
     "path": "/utilities/disclosure",
@@ -2318,7 +2318,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/utilities/drawer.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/utilities/drawer.mdx",
     "fileName": "drawer.mdx",
     "name": "drawer",
     "path": "/utilities/drawer",
@@ -2329,7 +2329,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/utilities/modal.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/utilities/modal.mdx",
     "fileName": "modal.mdx",
     "name": "modal",
     "path": "/utilities/modal",
@@ -2340,7 +2340,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/utilities/overlay.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/utilities/overlay.mdx",
     "fileName": "overlay.mdx",
     "name": "overlay",
     "path": "/utilities/overlay",
@@ -2351,7 +2351,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/utilities/portal.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/utilities/portal.mdx",
     "fileName": "portal.mdx",
     "name": "portal",
     "path": "/utilities/portal",
@@ -2362,7 +2362,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/utilities/rover.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/utilities/rover.mdx",
     "fileName": "rover.mdx",
     "name": "rover",
     "path": "/utilities/rover",
@@ -2373,7 +2373,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/utilities/tabbable.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/utilities/tabbable.mdx",
     "fileName": "tabbable.mdx",
     "name": "tabbable",
     "path": "/utilities/tabbable",
@@ -2384,7 +2384,7 @@
     }
   },
   {
-    "filePath": "/Users/josh/Documents/bumbag/bumbag-ui/website/pages/docs/variants.mdx",
+    "filePath": "/Users/jake/git/bumbag-ui/website/pages/docs/variants.mdx",
     "fileName": "variants.mdx",
     "name": "variants",
     "path": "/variants",


### PR DESCRIPTION
--BUG--
There was an issue with the autofocus that was causing the select menu to become 'jammed' after more than one click when the hasSearch prop was passed in.  meaning the user could no longer access the menu 

--PROPOSED CHANGES--
I propose we fix the autofocus for the search input inside the select menu 

--CHANGES MADE--
Fixed the autofocus issue by adding animated true to the dropdown menu state