### PR TITLE
disable regenerator runtime

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -8,6 +8,7 @@ module.exports = {
         targets: {
           browsers: 'defaults',
         },
+        "exclude": ["transform-regenerator"],
       },
     ],
     '@babel/preset-react',


### PR DESCRIPTION
regenerator-runtime can cause issues with strict CSP's that block unsafe evals.  It would be nice to not have this in the bumbag build