### PR TITLE
feature: add renderTopActions and renderBottomActions to autosuggest

### DIFF
--- a/packages/bumbag/src/Autosuggest/Autosuggest.styles.ts
+++ b/packages/bumbag/src/Autosuggest/Autosuggest.styles.ts
@@ -14,6 +14,8 @@ export const AutosuggestPopover = (styleProps) => cssClass`
     max-width: 100%;
     width: 100%;
     max-height: ${styleProps.popoverHeight};
+    display: flex;
+    flex-direction: column;
   }
 
   & {

--- a/packages/bumbag/src/Autosuggest/Autosuggest.tsx
+++ b/packages/bumbag/src/Autosuggest/Autosuggest.tsx
@@ -74,12 +74,14 @@ export type LocalAutosuggestProps = {
   /** Sets the loading text when more options are loading (via pagination). */
   loadingMoreText?: string;
 
+  renderBottomActions?: any;
   renderClearButton?: any;
   renderError?: any;
   renderEmpty?: any;
   renderLoading?: any;
   renderLoadingMore?: any;
   renderOption?: any;
+  renderTopActions?: any;
 
   clearButtonProps?: Partial<ButtonProps>;
   inputProps?: Partial<InputProps>;
@@ -239,12 +241,14 @@ const useProps = createHook<AutosuggestProps>(
       options: initialOptions,
       overrides,
       pagination,
+      renderBottomActions,
       renderClearButton: ClearButton,
       renderEmpty: Empty,
       renderError: Error,
       renderLoading: Loading,
       renderLoadingMore: LoadingMore,
       renderOption: Option,
+      renderTopActions,
       placeholder,
       restrictToOptions,
       state,
@@ -645,6 +649,8 @@ const useProps = createHook<AutosuggestProps>(
             value={inputValue}
           />
           <DropdownMenuPopover
+            display="flex"
+            flexDirection="column"
             {...dropdownMenu}
             ref={popoverRef}
             className={dropdownMenuPopoverClassName}
@@ -659,54 +665,58 @@ const useProps = createHook<AutosuggestProps>(
             {...popoverProps}
           >
             {dropdownMenu.visible && (
-              <Box use="ul" className={itemsWrapperClassName} onScroll={handleScrollPopover} overrides={overrides}>
-                {isSuccess ? (
-                  <React.Fragment>
-                    {filteredOptions
-                      .slice(0, limit)
-                      .filter(Boolean)
-                      .map((option, index) => (
-                        <AutosuggestItem
-                          key={option.key || index}
-                          {...dropdownMenu}
-                          aria-selected={highlightedIndex === index}
-                          aria-disabled={option.disabled}
-                          disabled={option.disabled}
-                          iconAfter={option.iconAfter}
-                          iconAfterProps={option.iconAfterProps}
-                          iconBefore={option.iconBefore}
-                          iconBeforeProps={option.iconBeforeProps}
-                          onClick={handleClickItem(index, option)}
-                          overrides={overrides}
-                          {...itemProps}
-                        >
-                          <Option
-                            label={option.label}
-                            inputValue={inputValue}
-                            option={option}
+              <React.Fragment>
+                {renderTopActions && renderTopActions({ StaticItem: AutosuggestStaticItem })}
+                <Box use="ul" onScroll={handleScrollPopover} className={itemsWrapperClassName} overrides={overrides}>
+                  {isSuccess ? (
+                    <React.Fragment>
+                      {filteredOptions
+                        .slice(0, limit)
+                        .filter(Boolean)
+                        .map((option, index) => (
+                          <AutosuggestItem
+                            key={option.key || index}
+                            {...dropdownMenu}
+                            aria-selected={highlightedIndex === index}
+                            aria-disabled={option.disabled}
+                            disabled={option.disabled}
+                            iconAfter={option.iconAfter}
+                            iconAfterProps={option.iconAfterProps}
+                            iconBefore={option.iconBefore}
+                            iconBeforeProps={option.iconBeforeProps}
+                            onClick={handleClickItem(index, option)}
                             overrides={overrides}
-                            MatchedLabel={(props) => (
-                              <MatchedLabel label={option.label} inputValue={inputValue} {...props} />
-                            )}
-                          />
-                        </AutosuggestItem>
-                      ))}
-                    {isLoadingMore && <LoadingMore loadingText={loadingMoreText} overrides={overrides} />}
-                  </React.Fragment>
-                ) : isLoading ? (
-                  <Loading loadingText={loadingText} overrides={overrides} />
-                ) : isError ? (
-                  <Error errorText={errorText} overrides={overrides} />
-                ) : (
-                  <Empty
-                    emptyText={emptyText}
-                    inputValue={inputValue}
-                    create={handleCreate}
-                    itemProps={{ 'aria-selected': highlightedIndex === 0 }}
-                    overrides={overrides}
-                  />
-                )}
-              </Box>
+                            {...itemProps}
+                          >
+                            <Option
+                              label={option.label}
+                              inputValue={inputValue}
+                              option={option}
+                              overrides={overrides}
+                              MatchedLabel={(props) => (
+                                <MatchedLabel label={option.label} inputValue={inputValue} {...props} />
+                              )}
+                            />
+                          </AutosuggestItem>
+                        ))}
+                      {isLoadingMore && <LoadingMore loadingText={loadingMoreText} overrides={overrides} />}
+                    </React.Fragment>
+                  ) : isLoading ? (
+                    <Loading loadingText={loadingText} overrides={overrides} />
+                  ) : isError ? (
+                    <Error errorText={errorText} overrides={overrides} />
+                  ) : (
+                    <Empty
+                      emptyText={emptyText}
+                      inputValue={inputValue}
+                      create={handleCreate}
+                      itemProps={{ 'aria-selected': highlightedIndex === 0 }}
+                      overrides={overrides}
+                    />
+                  )}
+                </Box>
+                {renderBottomActions && renderBottomActions({ StaticItem: AutosuggestStaticItem })}
+              </React.Fragment>
             )}
           </DropdownMenuPopover>
         </AutosuggestContext.Provider>
@@ -723,12 +733,14 @@ const useProps = createHook<AutosuggestProps>(
       loadingMoreText: 'Loading...',
       popoverHeight: '300px',
       options: [],
+      renderBottomActions: () => {},
       renderClearButton: ClearButton,
       renderEmpty: Empty,
       renderError: Error,
       renderLoading: Loading,
       renderLoadingMore: Loading,
       renderOption: MatchedLabel,
+      renderTopActions: () => {},
     },
     themeKey: 'Autosuggest',
   }

--- a/website/pages/docs/form/autosuggest.mdx
+++ b/website/pages/docs/form/autosuggest.mdx
@@ -476,6 +476,78 @@ function Example() {
 }
 ```
 
+### Custom top actions component
+
+You can render a custom top actions component with the `renderTopActions` prop.
+
+```function-live
+function Example() {
+  const [value, setValue] = React.useState({ label: '' });
+
+  return (
+    <Autosuggest
+      renderTopActions={({ StaticItem }) =>
+        <StaticItem hideDropdownOnClick>
+          <Link>
+            Create a fruit
+          </Link>
+        </StaticItem>
+      }
+      restrictToOptions
+      onChange={setValue}
+      options={[
+        { key: 1, label: 'Apples', value: 'apples' },
+        { key: 2, label: 'Bananas', value: 'bananas' },
+        { key: 3, label: 'Oranges', value: 'oranges' },
+        { key: 4, label: 'Mangos', value: 'mangos' },
+        { key: 5, label: 'Peaches', value: 'peaches' },
+        { key: 6, label: 'Strawberries', value: 'Strawberries' },
+        { key: 7, label: 'Pineapples', value: 'pineapples' },
+        { key: 8, label: 'Figs', value: 'figs' }
+      ]}
+      placeholder="Search for a fruit..."
+      value={value}
+    />
+  )
+}
+```
+
+### Custom bottom actions component
+
+You can render a custom bottom actions component with the `renderBottomActions` prop.
+
+```function-live
+function Example() {
+  const [value, setValue] = React.useState({ label: '' });
+
+  return (
+    <Autosuggest
+      renderBottomActions={({ StaticItem }) =>
+        <StaticItem hideDropdownOnClick>
+          <Link>
+            Create a fruit
+          </Link>
+        </StaticItem>
+      }
+      restrictToOptions
+      onChange={setValue}
+      options={[
+        { key: 1, label: 'Apples', value: 'apples' },
+        { key: 2, label: 'Bananas', value: 'bananas' },
+        { key: 3, label: 'Oranges', value: 'oranges' },
+        { key: 4, label: 'Mangos', value: 'mangos' },
+        { key: 5, label: 'Peaches', value: 'peaches' },
+        { key: 6, label: 'Strawberries', value: 'Strawberries' },
+        { key: 7, label: 'Pineapples', value: 'pineapples' },
+        { key: 8, label: 'Figs', value: 'figs' }
+      ]}
+      placeholder="Search for a fruit..."
+      value={value}
+    />
+  )
+}
+```
+
 ### Option icons
 
 ```function-live
@@ -814,6 +886,10 @@ Sets the loading text when more options are loading (via pagination).
 
 <Divider marginTop="major-2" marginBottom="major-2" />
 
+**<Code fontSize="150" marginRight="major-1">renderBottomActions</Code>** <Code fontSize="100" palette="primary">any</Code> 
+
+<Divider marginTop="major-2" marginBottom="major-2" />
+
 **<Code fontSize="150" marginRight="major-1">renderClearButton</Code>** <Code fontSize="100" palette="primary">any</Code> 
 
 <Divider marginTop="major-2" marginBottom="major-2" />
@@ -835,6 +911,10 @@ Sets the loading text when more options are loading (via pagination).
 <Divider marginTop="major-2" marginBottom="major-2" />
 
 **<Code fontSize="150" marginRight="major-1">renderOption</Code>** <Code fontSize="100" palette="primary">any</Code> 
+
+<Divider marginTop="major-2" marginBottom="major-2" />
+
+**<Code fontSize="150" marginRight="major-1">renderTopActions</Code>** <Code fontSize="100" palette="primary">any</Code> 
 
 <Divider marginTop="major-2" marginBottom="major-2" />
 
@@ -1198,6 +1278,10 @@ Sets the loading text when more options are loading (via pagination).
 
 <Divider marginTop="major-2" marginBottom="major-2" />
 
+**<Code fontSize="150" marginRight="major-1">renderBottomActions</Code>** <Code fontSize="100" palette="primary">any</Code> 
+
+<Divider marginTop="major-2" marginBottom="major-2" />
+
 **<Code fontSize="150" marginRight="major-1">renderClearButton</Code>** <Code fontSize="100" palette="primary">any</Code> 
 
 <Divider marginTop="major-2" marginBottom="major-2" />
@@ -1219,6 +1303,10 @@ Sets the loading text when more options are loading (via pagination).
 <Divider marginTop="major-2" marginBottom="major-2" />
 
 **<Code fontSize="150" marginRight="major-1">renderOption</Code>** <Code fontSize="100" palette="primary">any</Code> 
+
+<Divider marginTop="major-2" marginBottom="major-2" />
+
+**<Code fontSize="150" marginRight="major-1">renderTopActions</Code>** <Code fontSize="100" palette="primary">any</Code> 
 
 <Divider marginTop="major-2" marginBottom="major-2" />
 


### PR DESCRIPTION
I thought it would be nice to add the same `renderTopActions` and `renderBottomActions` props to the `Autosuggest` that we already have for the `SelectMenu`.