### PR TITLE
fix: column spread prop type

### DIFF
--- a/packages/bumbag/src/types/props.ts
+++ b/packages/bumbag/src/types/props.ts
@@ -4,7 +4,7 @@ export type Altitude = Flexible<'100' | '200' | '300' | '400' | '500' | '600' | 
 export type BorderRadii = Flexible<'default' | '1' | '2' | '3' | '4' | '5' | '6' | '7', string>;
 export type ButtonType = 'button' | 'submit' | 'reset';
 export type Breakpoint = Flexible<'fullHD' | 'widescreen' | 'desktop' | 'tablet' | 'mobile', string>;
-export type ColumnSpread = number;
+export type ColumnSpread = Flexible<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12, number>;
 export type ColumnSpreadOffset = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 'left' | 'both' | 'right';
 export type GradientDirection =
   | 'top'

--- a/packages/bumbag/src/types/props.ts
+++ b/packages/bumbag/src/types/props.ts
@@ -4,7 +4,7 @@ export type Altitude = Flexible<'100' | '200' | '300' | '400' | '500' | '600' | 
 export type BorderRadii = Flexible<'default' | '1' | '2' | '3' | '4' | '5' | '6' | '7', string>;
 export type ButtonType = 'button' | 'submit' | 'reset';
 export type Breakpoint = Flexible<'fullHD' | 'widescreen' | 'desktop' | 'tablet' | 'mobile', string>;
-export type ColumnSpread = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type ColumnSpread = number;
 export type ColumnSpreadOffset = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 'left' | 'both' | 'right';
 export type GradientDirection =
   | 'top'


### PR DESCRIPTION
When calculating the width for a column using the `spread` prop, the
value is divided by 12 and set to the percentage of the result:

https://github.com/jxom/bumbag-ui/blob/main/packages/bumbag/src/Columns/Columns.styles.ts#L62

The type for the prop only allows values 1-12, but float values are also
applicable for the prop. This PR generalises the type to allow any
number to be passed.